### PR TITLE
Add norelativenumber where necessary

### DIFF
--- a/autoload/vc/act.vim
+++ b/autoload/vc/act.vim
@@ -28,7 +28,7 @@ fun! vc#act#blame(argsd)
     let b:vc_repo = a:argsd.meta.repo
     setlocal filetype=vcblame
     setlocal buftype=nofile bufhidden=wipe nobuflisted noswapfile
-    setlocal nowrap nofoldenable nonumber nomodified readonly
+    setlocal nowrap nofoldenable nonumber norelativenumber nomodified readonly
     setlocal scrollbind
     wincmd p " return to previous window
     setlocal scrollbind

--- a/autoload/vc/blank.vim
+++ b/autoload/vc/blank.vim
@@ -24,7 +24,7 @@ fun! s:setup(cmdsdict) "{{{2
     let jwinnr = bufwinnr(s:bwinname)
     silent! exe  jwinnr < 0 ? 'keepa botright 1new ' .
                 \ fnameescape(s:bwinname) : jwinnr . 'wincmd w'
-    setl nobuflisted noswapfile nowrap nonumber nocuc nomodeline nomore nolist wfh
+    setl nobuflisted noswapfile nowrap nonumber norelativenumber nocuc nomodeline nomore nolist wfh
 	setl tw=0 bt=acwrite bh=wipe
     silent! exe 'resize ' . g:vc_window_max_size 
 	au VCOnWrite BufWriteCmd <buffer> call vc#blank#callonwrite()

--- a/autoload/vc/syntax.vim
+++ b/autoload/vc/syntax.vim
@@ -8,7 +8,7 @@
 
 fun! vc#syntax#build() "{{{2
     setl nobuflisted
-    setl noswapfile nowrap nonumber cul nocuc nomodeline nomore nospell nolist wfh
+    setl noswapfile nowrap nonumber norelativenumber cul nocuc nomodeline nomore nospell nolist wfh
 	setl fdc=0 fdl=99 tw=0 bt=nofile bh=unload
 
     silent! exe 'resize ' . g:vc_window_max_size 


### PR DESCRIPTION
When relativenumber is enabled, the "nonumber" option doesn't turn off
relative numbering.  Add "norelativenumber" to all places that have
"nonumber" to ensure line numbers are hidden.
