### PR TITLE
Request: prevent multiple windows from being left in the diff state

### DIFF
--- a/autoload/vc/act.vim
+++ b/autoload/vc/act.vim
@@ -88,6 +88,10 @@ fun! vc#act#diffme(repo, revision, path, force)
 
     diffthis | exec 'keepalt vnew! ' vc#utils#fnameescape(fname)
     exec cmd |  diffthis
+    call diffusable#diff_with_partner(winnr('#'))
+    wincmd p
+    call diffusable#diff_with_partner(winnr('#'))
+    wincmd p
     retu s:diffsetup(a:repo, islocal, a:revision, a:path, a:force, fname, cmd)
 endf
 


### PR DESCRIPTION
This is more of a suggested feature than an actual pull request. This change adds a dependency on idbrii/vim-diffusable.

[vim-diffusable](https://github.com/idbrii/vim-diffusable) sets up "partnered" diff windows so if one window
closes, it turns off diff for the other window. This prevents multiple
windows from being left in the &diff state so if you open more diffs,
vim isn't trying to diff unrelated files.

Does this seem like a useful feature to you?