### PR TITLE
Make blame match current source line

### DIFF
--- a/autoload/vc/act.vim
+++ b/autoload/vc/act.vim
@@ -30,8 +30,14 @@ fun! vc#act#blame(argsd)
     setlocal buftype=nofile bufhidden=wipe nobuflisted noswapfile
     setlocal nowrap nofoldenable nonumber norelativenumber nomodified readonly
     setlocal scrollbind
+    if exists('+cursorbind')
+        setlocal cursorbind
+    endif
     wincmd p " return to previous window
     setlocal scrollbind
+    if exists('+cursorbind')
+        setlocal cursorbind
+    endif
     syncbind
     retu vc#passed()
 endf


### PR DESCRIPTION
In addition to scrollbind, use cursorbind if available. This will make
switching to blame window to check commit behind a line work (cursor position will be on the corresponding blame line).

One issue that comes from this is that cursorbind is not removed (same problem exists for scrollbind). Whatever method is used to solve #10 could probably solve this too.