### PR TITLE
Introduce no_vc_maps to prevent clobbering +

### DIFF
--- a/plugin/vc.vim
+++ b/plugin/vc.vim
@@ -50,8 +50,11 @@ if index(vc#repos#repos(), "-hg") >= 0
 endif
 
 com! -n=* VCGrep call vc#grep#do("", <q-args>)
-nmap + :<C-u>call vc#grep#do("*".fnamemodify(expand('%'), ':e'), expand("<cword>")) <CR>
-vmap + :<C-u>call vc#grep#do("*".fnamemodify(expand('%'), ':e'), expand("<cword>")) <CR>
+
+if !exists("g:no_vc_maps") || g:no_vc_maps == 0
+    nmap + :<C-u>call vc#grep#do("*".fnamemodify(expand('%'), ':e'), expand("<cword>")) <CR>
+    vmap + :<C-u>call vc#grep#do("*".fnamemodify(expand('%'), ':e'), expand("<cword>")) <CR>
+endif
 
 "}}}
 


### PR DESCRIPTION
VC assumes the users isn't already using + for something useful and this
is unusual since all other maps use leader. Provide a map for users who
don't want their + map clobbered.