### PR TITLE
Allow user to specify a template for commit msgs

### DIFF
--- a/autoload/vc/utils.vim
+++ b/autoload/vc/utils.vim
@@ -576,7 +576,7 @@ fun! vc#utils#commitheader(meta, thefiles, dscr) "{{{2
         call add(blines, "VC: Operations : " . a:dscr)
     endif
     call add(blines, 'VC: ---------------Enter Comments below this line--------------------')
-    call add(blines, '')
+    call extend(blines, get(g:, "vc_commit_msg_template", ['']))
     let b:vc_meta = a:meta
     retu blines
 endf

--- a/doc/vc.txt
+++ b/doc/vc.txt
@@ -1054,6 +1054,14 @@ is enabled. To disable at .vimrc code >
     let g:vc_autocomplete_svnurls = 0
 <
 
+                                                  *'g:vc_commit_msg_template'*
+Supply a template that's inserted into the |:VCCommit| buffer before use.
+Default is a blank line. Each element in the list will be a line, so empty
+string will be a blank line. To setup a template in .vimrc: >
+
+    let g:vc_commit_msg_template = ['[PRJ] ', '', '', 'Review:', '', 'Test:']
+<
+
                                              *'g:vc_commit_allow_blank_lines'*
 This option allows blank lines inbetween the comments, Default strips of the 
 blank lines. When blank lines are available as comments VCLog will not show


### PR DESCRIPTION
Add g:vc_commit_msg_template: a List the user can fill with lines they
want inserted into their commit messages (to follow a company standard
or create section headers they frequently use).

If not supplied, we just use the default blank line.